### PR TITLE
fix: patch setup script bugs and minor code quality issues

### DIFF
--- a/scripts/highlight.sh
+++ b/scripts/highlight.sh
@@ -7,4 +7,6 @@ FILE="$1"
 START="$2"
 END="$3"
 
-echo "{\"file\":\"$FILE\",\"start\":$START,\"end\":$END}" > ~/.claude-highlight.json
+# Use python/node-free JSON construction with proper escaping
+ESCAPED_FILE=$(printf '%s' "$FILE" | sed 's/\\/\\\\/g; s/"/\\"/g')
+printf '{"file":"%s","start":%d,"end":%d}\n' "$ESCAPED_FILE" "$START" "$END" > ~/.claude-highlight.json

--- a/scripts/kokoro_server.py
+++ b/scripts/kokoro_server.py
@@ -157,6 +157,7 @@ if __name__ == "__main__":
             stderr=log,
             start_new_session=True,
         )
+        log.close()
         print(f"[kokoro-server] Started daemon (PID {proc.pid})")
         sys.exit(0)
 

--- a/scripts/kokoro_speak.py
+++ b/scripts/kokoro_speak.py
@@ -30,11 +30,13 @@ def server_running() -> bool:
 def start_server():
     """Start the TTS server as a daemon and wait for it to be ready."""
     print("[kokoro-tts] Starting server (first-time model load ~5s)...", flush=True)
+    log = open("/tmp/kokoro-tts.log", "a")
     subprocess.Popen(
         [VENV_PYTHON, SERVER_SCRIPT, "--daemon"],
-        stdout=open("/tmp/kokoro-tts.log", "a"),
+        stdout=log,
         stderr=subprocess.STDOUT,
     )
+    log.close()
     # Wait for server to be ready (up to 30s for model loading)
     import time
     for _ in range(60):

--- a/setup.sh
+++ b/setup.sh
@@ -165,9 +165,12 @@ npm run compile --silent 2>&1
 ok "TypeScript compiled"
 
 # Package as VSIX
-VSIX_FILE="$EXT_DIR/code-explainer-0.1.0.vsix"
 npx @vscode/vsce package --no-dependencies --allow-star-activation --allow-missing-repository 2>&1 | grep -E "^( DONE|VSIX)" | head -1
-ok "VSIX packaged"
+VSIX_FILE=$(ls -t "$EXT_DIR"/*.vsix 2>/dev/null | head -1)
+if [[ -z "$VSIX_FILE" ]]; then
+    fail "VSIX packaging failed — no .vsix file found"
+fi
+ok "VSIX packaged: $(basename "$VSIX_FILE")"
 
 # Install extension in all detected editors
 for EDITOR_CLI in "${EDITORS[@]}"; do
@@ -191,7 +194,7 @@ ok "All scripts marked executable"
 header "Pre-downloading Kokoro voice model"
 
 echo "  Downloading model (~330 MB on first run)..."
-"$VENV_PYTHON" -c "
+if "$VENV_PYTHON" -c "
 from mlx_audio.tts.generate import generate_audio
 import tempfile, os
 with tempfile.TemporaryDirectory() as d:
@@ -203,10 +206,7 @@ with tempfile.TemporaryDirectory() as d:
         file_prefix=os.path.join(d, 'test'),
         verbose=False,
     )
-print('ok')
-" 2>&1 | grep -v "^Fetching\|^$\|INFO\|pip\|spacy\|Collecting\|Downloading\|Installing\|Successfully\|✔" | tail -1
-
-if [[ $? -eq 0 ]]; then
+" 2>&1 | grep -v "^Fetching\|^$\|INFO\|pip\|spacy\|Collecting\|Downloading\|Installing\|Successfully\|✔" | tail -1; then
     ok "Kokoro model downloaded and cached"
 else
     warn "Model download had issues — will retry on first use"

--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -2,6 +2,7 @@
 node_modules/**
 src/**
 tsconfig.json
+package-lock.json
 **/*.ts
 **/*.map
 .gitignore


### PR DESCRIPTION
## Summary
- **VSIX filename**: derived dynamically via glob instead of hardcoding `code-explainer-0.1.0.vsix` — no longer breaks on version bumps
- **Model download check**: `$?` was capturing `tail`'s exit code, not Python's — moved into `if` condition
- **highlight.sh JSON injection**: escape backslashes and quotes in file paths before writing JSON
- **File handle leaks**: close log file handles after `Popen` in `kokoro_speak.py` and `kokoro_server.py`
- **VSIX bloat**: exclude `package-lock.json` from the packaged extension

## Test plan
- [ ] Run `./setup.sh` end-to-end on a clean machine
- [ ] Verify VSIX installs correctly after a version bump in `package.json`
- [ ] Test `highlight.sh` with a file path containing quotes or backslashes
- [ ] Confirm TTS server starts and speaks without leaked handles

🤖 Generated with [Claude Code](https://claude.com/claude-code)