### PR TITLE
fix: improve audio gate UX with pulse play button and restart option

### DIFF
--- a/vscode-extension/media/sidebar.css
+++ b/vscode-extension/media/sidebar.css
@@ -271,25 +271,50 @@ body {
 
 /* ── Done view ── */
 
-.done-text {
+.done-card {
 	text-align: center;
 	margin-top: 40px;
+}
+
+.done-text {
 	font-size: 1.1em;
 	font-weight: 600;
 }
 
 .done-summary {
-	text-align: center;
 	margin-top: 8px;
 	opacity: 0.6;
+}
+
+.done-hint {
+	margin-top: 16px;
+	font-size: 0.85em;
+	opacity: 0.5;
+}
+
+.done-restart-btn {
+	margin-top: 16px;
+	background: var(--vscode-button-secondaryBackground);
+	color: var(--vscode-button-secondaryForeground);
+	border: none;
+	border-radius: 6px;
+	padding: 8px 20px;
+	font-size: 0.9em;
+	cursor: pointer;
+}
+
+.done-restart-btn:hover {
+	background: var(--vscode-button-secondaryHoverBackground);
 }
 
 /* ── Audio gate overlay ── */
 
 #audio-gate-overlay {
 	display: flex;
-	justify-content: center;
-	padding: 12px;
+	flex-direction: column;
+	align-items: center;
+	gap: 10px;
+	padding: 20px 12px;
 	margin-bottom: 12px;
 }
 
@@ -297,12 +322,40 @@ body {
 	background: var(--vscode-button-background);
 	color: var(--vscode-button-foreground);
 	border: none;
-	border-radius: 6px;
-	padding: 8px 20px;
-	font-size: 0.95em;
+	border-radius: 50%;
+	width: 56px;
+	height: 56px;
+	font-size: 1.4em;
 	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	animation: pulse-ring 2s ease-out infinite;
+	position: relative;
+}
+
+#audio-gate-btn .play-icon {
+	margin-left: 3px; /* optical centering for play triangle */
 }
 
 #audio-gate-btn:hover {
 	background: var(--vscode-button-hoverBackground);
+	animation: none;
+}
+
+.audio-gate-hint {
+	font-size: 0.8em;
+	opacity: 0.6;
+}
+
+@keyframes pulse-ring {
+	0% {
+		box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.4);
+	}
+	70% {
+		box-shadow: 0 0 0 12px rgba(255, 255, 255, 0);
+	}
+	100% {
+		box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
+	}
 }

--- a/vscode-extension/media/sidebar.js
+++ b/vscode-extension/media/sidebar.js
@@ -68,7 +68,12 @@ function showAudioGateOverlay() {
 
 	const overlay = document.createElement("div");
 	overlay.id = "audio-gate-overlay";
-	overlay.innerHTML = `<button id="audio-gate-btn">Click to enable audio</button>`;
+	overlay.innerHTML = `
+		<button id="audio-gate-btn" title="Click to start audio playback">
+			<span class="play-icon">&#9654;</span>
+		</button>
+		<span class="audio-gate-hint">Click play to start audio</span>
+	`;
 	document.getElementById("active-view").prepend(overlay);
 
 	document.getElementById("audio-gate-btn").addEventListener("click", () => {
@@ -317,6 +322,10 @@ document.getElementById("btn-prev").addEventListener("click", () => {
 
 document.getElementById("btn-deeper").addEventListener("click", () => {
 	vscode.postMessage({ type: "go_deeper" });
+});
+
+document.getElementById("btn-restart").addEventListener("click", () => {
+	vscode.postMessage({ type: "restart" });
 });
 
 document.getElementById("btn-zoom-out").addEventListener("click", () => {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -248,6 +248,7 @@ export function activate(context: vscode.ExtensionContext): void {
 		switch (msg.type) {
 			case "set_plan":
 				walkthrough.setPlan(msg.title, msg.segments);
+				sidebar.reveal();
 				break;
 			case "insert_after":
 				walkthrough.insertAfter(msg.afterSegment, msg.segments);
@@ -339,6 +340,13 @@ export function activate(context: vscode.ExtensionContext): void {
 			case "mute_toggle":
 				// Mute is handled in webview's Web Audio GainNode
 				break;
+			case "restart": {
+				const segments = walkthrough.getState().segments;
+				if (segments.length > 0) {
+					walkthrough.goto(segments[0].id);
+				}
+				break;
+			}
 		}
 	});
 

--- a/vscode-extension/src/sidebar.ts
+++ b/vscode-extension/src/sidebar.ts
@@ -33,6 +33,16 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 		});
 	}
 
+	/** Reveal and focus the sidebar panel */
+	reveal(): void {
+		if (this.view) {
+			this.view.show?.(true);
+		} else {
+			// If webview isn't resolved yet, open the sidebar view
+			vscode.commands.executeCommand("codeExplainer.sidebar.focus");
+		}
+	}
+
 	/** Send a message to the webview */
 	postMessage(msg: ToWebviewMessage): void {
 		this.view?.webview.postMessage(msg);
@@ -161,8 +171,12 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 	</div>
 
 	<div id="done-view" style="display:none;">
-		<p class="done-text">Walkthrough complete</p>
-		<p id="done-summary" class="done-summary"></p>
+		<div class="done-card">
+			<p class="done-text">Walkthrough complete</p>
+			<p id="done-summary" class="done-summary"></p>
+			<p class="done-hint">Have more questions? Ask your coding agent!</p>
+			<button id="btn-restart" class="done-restart-btn">Restart Walkthrough</button>
+		</div>
 	</div>
 
 	<script nonce="${nonce}" src="${scriptUri}"></script>

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -165,6 +165,10 @@ export interface WebviewMuteToggleMessage {
 	type: "mute_toggle";
 }
 
+export interface WebviewRestartMessage {
+	type: "restart";
+}
+
 export type FromWebviewMessage =
 	| WebviewPlayPauseMessage
 	| WebviewNextMessage
@@ -175,4 +179,5 @@ export type FromWebviewMessage =
 	| WebviewSpeedChangeMessage
 	| WebviewVolumeChangeMessage
 	| WebviewVoiceChangeMessage
-	| WebviewMuteToggleMessage;
+	| WebviewMuteToggleMessage
+	| WebviewRestartMessage;


### PR DESCRIPTION
## Summary
- Replace plain "Click to enable audio" button with a circular play button (▶) with pulse animation so users notice it immediately
- Auto-focus the sidebar panel when a walkthrough starts (`set_plan`)
- Add "Restart Walkthrough" button and helpful hint on the completion screen

## Test plan
- [ ] Start a walkthrough and verify the sidebar auto-focuses
- [ ] Check that the audio gate shows a pulsing circular play button instead of the old text button
- [ ] Complete a walkthrough and verify the done screen shows restart button and hint text
- [ ] Click restart and verify it jumps back to segment 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)