### PR TITLE
fix: sync sub-highlight advancement with actual audio playback

### DIFF
--- a/vscode-extension/media/sidebar.js
+++ b/vscode-extension/media/sidebar.js
@@ -140,10 +140,21 @@ function stopAudio() {
 }
 
 function onAudioEnd() {
-	// If using multi-highlights, the extension controls advancement.
-	// audio_end just means this chunk finished — don't auto-advance segments.
+	// Multi-highlight mode: wait for actual Web Audio playback to finish,
+	// then signal the extension so it can advance to the next sub-highlight.
 	if (totalHighlights >= 1) {
-		audioPlaying = false;
+		if (activeSources.length === 0) {
+			audioPlaying = false;
+			vscode.postMessage({ type: "playback_complete" });
+			return;
+		}
+		const lastSource = activeSources[activeSources.length - 1];
+		const originalOnEnded = lastSource.onended;
+		lastSource.onended = (e) => {
+			if (originalOnEnded) originalOnEnded.call(lastSource, e);
+			audioPlaying = false;
+			vscode.postMessage({ type: "playback_complete" });
+		};
 		return;
 	}
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -83,6 +83,10 @@ function playHighlightChunk(
 		highlightSubRange(segment.file, highlight.start, highlight.end).catch(() => {});
 
 		if (highlight.ttsText && isTTSAvailable()) {
+			// Wait for the webview to signal actual playback completion,
+			// not just the TTS server finishing its stream.
+			sidebar.waitForPlaybackComplete().then(resolve);
+
 			abortFn = streamTTS(
 				highlight.ttsText,
 				{ voice, speed },
@@ -91,7 +95,6 @@ function playHighlightChunk(
 				},
 				() => {
 					if (!aborted) sidebar.sendAudioEnd();
-					resolve();
 				},
 				(err) => {
 					console.error("[code-explainer] TTS error:", err);

--- a/vscode-extension/src/sidebar.ts
+++ b/vscode-extension/src/sidebar.ts
@@ -7,6 +7,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 
 	private view?: vscode.WebviewView;
 	private onMessage?: (msg: FromWebviewMessage) => void;
+	private playbackCompleteResolve?: () => void;
 
 	constructor(private readonly extensionUri: vscode.Uri) {}
 
@@ -29,6 +30,11 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 		webviewView.webview.html = this.getHtml(webviewView.webview);
 
 		webviewView.webview.onDidReceiveMessage((msg: FromWebviewMessage) => {
+			if (msg.type === "playback_complete") {
+				this.playbackCompleteResolve?.();
+				this.playbackCompleteResolve = undefined;
+				return;
+			}
 			this.onMessage?.(msg);
 		});
 	}
@@ -74,6 +80,16 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 
 	sendAudioStop(): void {
 		this.postMessage({ type: "audio_stop" });
+		// Resolve any pending playback wait since audio was forcefully stopped
+		this.playbackCompleteResolve?.();
+		this.playbackCompleteResolve = undefined;
+	}
+
+	/** Returns a promise that resolves when the webview signals playback is done */
+	waitForPlaybackComplete(): Promise<void> {
+		return new Promise((resolve) => {
+			this.playbackCompleteResolve = resolve;
+		});
 	}
 
 	sendHighlightAdvance(highlightIndex: number, totalHighlights: number): void {

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -169,6 +169,10 @@ export interface WebviewRestartMessage {
 	type: "restart";
 }
 
+export interface WebviewPlaybackCompleteMessage {
+	type: "playback_complete";
+}
+
 export type FromWebviewMessage =
 	| WebviewPlayPauseMessage
 	| WebviewNextMessage
@@ -180,4 +184,5 @@ export type FromWebviewMessage =
 	| WebviewVolumeChangeMessage
 	| WebviewVoiceChangeMessage
 	| WebviewMuteToggleMessage
-	| WebviewRestartMessage;
+	| WebviewRestartMessage
+	| WebviewPlaybackCompleteMessage;


### PR DESCRIPTION
## Summary
- In multi-highlight mode, the extension was racing ahead of narration — it advanced to the next sub-highlight when the TTS server finished *streaming*, not when the webview finished *playing*
- Added a `playback_complete` message from webview → extension that fires after the last `AudioBufferSourceNode.onended`, using the same proven pattern from single-highlight mode
- `sendAudioStop()` also resolves any pending playback wait to prevent promise leaks on abort

## Test plan
- [ ] Start a multi-highlight walkthrough with TTS enabled
- [ ] Verify sub-highlights now stay in sync with audio narration (no racing ahead)
- [ ] Verify manually skipping (next/prev) still works without hanging
- [ ] Verify single-highlight (legacy) mode still auto-advances correctly
- [ ] Verify pause/stop mid-highlight doesn't leak promises

🤖 Generated with [Claude Code](https://claude.com/claude-code)