### PR TITLE
docs: add multi-agent installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,19 +43,52 @@ Your agent will clone the repo into the skills directory, run `setup.sh`, and as
 <details>
 <summary>📋 Manual installation</summary>
 
+### Skill-native agents
+
+These agents support the `skills/<name>/SKILL.md` format natively. Clone directly into the skills directory:
+
+| Agent | Install commands |
+|-------|-----------------|
+| **Claude Code** | `git clone https://github.com/Royal-lobster/code-explainer.git ~/.claude/skills/explainer` |
+| **Amp** | `git clone https://github.com/Royal-lobster/code-explainer.git ~/.config/agents/skills/explainer` |
+| **OpenCode** | `git clone https://github.com/Royal-lobster/code-explainer.git ~/.config/opencode/skills/explainer` |
+| **Codex CLI** | `git clone https://github.com/Royal-lobster/code-explainer.git ~/.codex/skills/explainer` |
+
+Then run setup:
+
 ```bash
-# 1. Clone directly into skills directory
-mkdir -p ~/.claude/skills
-git clone https://github.com/Royal-lobster/code-explainer.git ~/.claude/skills/explainer
-
-# 2. Run setup (installs everything)
-~/.claude/skills/explainer/setup.sh
-
-# 3. Reload your editor
-# Cmd+Shift+P → "Developer: Reload Window"
+<SKILLS_DIR>/explainer/setup.sh
+# Reload your editor: Cmd+Shift+P → "Developer: Reload Window"
 ```
 
-The setup script handles:
+### Rule-based agents
+
+These agents use their own rules/instructions format. Clone to any location, run setup, then point your agent's rules at the `SKILL.md`:
+
+```bash
+# 1. Clone to a shared location
+git clone https://github.com/Royal-lobster/code-explainer.git ~/code-explainer
+
+# 2. Run setup
+~/code-explainer/setup.sh
+
+# 3. Reload your editor: Cmd+Shift+P → "Developer: Reload Window"
+```
+
+Then add a rule or instruction pointing to the skill:
+
+| Agent | How to add |
+|-------|------------|
+| **Cursor** | Add a `.cursor/rules/explainer.mdc` file in your project that includes the contents of `SKILL.md` |
+| **Windsurf** | Append the contents of `SKILL.md` to `~/.codeium/windsurf/memories/global_rules.md` |
+| **Kilo Code** | Copy `SKILL.md` to `~/.kilocode/rules/explainer.md` |
+| **Roo Code** | Copy `SKILL.md` to `~/.roo/rules/explainer.md` |
+| **Cline** | Copy `SKILL.md` to your `.clinerules/explainer.md` directory |
+
+> **Note:** The `SKILL.md` references relative paths (e.g., `docs/step1-assess.md`), so the full repo must exist at the cloned location. For rule-based agents, ensure paths in the copied rules resolve correctly or use absolute paths.
+
+### What setup.sh does
+
 - 🐍 Python venv creation with TTS engine (mlx-audio + sounddevice)
 - 🧩 VS Code extension build and installation (.vsix for VS Code + Cursor)
 - 🗣️ Voice model download (~330 MB)

--- a/setup.sh
+++ b/setup.sh
@@ -218,11 +218,75 @@ echo -e "${GREEN}${BOLD}╔═════════════════�
 echo -e "${GREEN}${BOLD}║   Setup complete!                            ║${NC}"
 echo -e "${GREEN}${BOLD}╚══════════════════════════════════════════════╝${NC}"
 echo ""
+echo -e "  ${BOLD}Skill installed at:${NC} $SCRIPT_DIR"
+echo ""
 echo -e "  ${BOLD}Next steps:${NC}"
 echo -e "  1. Reload your editor: ${BLUE}Cmd+Shift+P → 'Developer: Reload Window'${NC}"
-echo -e "  2. Copy skill to your agent: ${BLUE}cp -r $SCRIPT_DIR ~/.claude/skills/explainer${NC}"
-echo -e "     (skip if already there)"
-echo -e "  3. Use it: ${BLUE}/explainer <feature name>${NC}"
+
+# Detect which agents are available and print relevant guidance
+DETECTED_AGENTS=()
+
+if [[ "$SCRIPT_DIR" == *"/.claude/skills/"* ]]; then
+    DETECTED_AGENTS+=("Claude Code")
+elif [[ -d "$HOME/.claude" ]]; then
+    DETECTED_AGENTS+=("Claude Code")
+fi
+
+if [[ "$SCRIPT_DIR" == *"/.config/agents/skills/"* ]]; then
+    DETECTED_AGENTS+=("Amp")
+elif [[ -d "$HOME/.config/agents" ]]; then
+    DETECTED_AGENTS+=("Amp")
+fi
+
+if [[ "$SCRIPT_DIR" == *"/.config/opencode/skills/"* ]]; then
+    DETECTED_AGENTS+=("OpenCode")
+elif [[ -d "$HOME/.config/opencode" ]]; then
+    DETECTED_AGENTS+=("OpenCode")
+fi
+
+if [[ "$SCRIPT_DIR" == *"/.codex/skills/"* ]]; then
+    DETECTED_AGENTS+=("Codex CLI")
+elif [[ -d "$HOME/.codex" ]]; then
+    DETECTED_AGENTS+=("Codex CLI")
+fi
+
+# Check if skill is already in a known skills directory
+IN_SKILLS_DIR=false
+if [[ "$SCRIPT_DIR" == *"/skills/explainer"* ]]; then
+    IN_SKILLS_DIR=true
+fi
+
+if $IN_SKILLS_DIR; then
+    echo -e "  2. Use it: ${BLUE}/explainer <feature name>${NC}"
+else
+    echo -e "  2. Copy the skill to your agent's skills directory:"
+    echo ""
+    if [[ " ${DETECTED_AGENTS[*]} " =~ " Claude Code " ]]; then
+        echo -e "     ${BOLD}Claude Code:${NC}  ${BLUE}cp -r $SCRIPT_DIR ~/.claude/skills/explainer${NC}"
+    fi
+    if [[ " ${DETECTED_AGENTS[*]} " =~ " Amp " ]]; then
+        echo -e "     ${BOLD}Amp:${NC}          ${BLUE}cp -r $SCRIPT_DIR ~/.config/agents/skills/explainer${NC}"
+    fi
+    if [[ " ${DETECTED_AGENTS[*]} " =~ " OpenCode " ]]; then
+        echo -e "     ${BOLD}OpenCode:${NC}     ${BLUE}cp -r $SCRIPT_DIR ~/.config/opencode/skills/explainer${NC}"
+    fi
+    if [[ " ${DETECTED_AGENTS[*]} " =~ " Codex CLI " ]]; then
+        echo -e "     ${BOLD}Codex CLI:${NC}    ${BLUE}cp -r $SCRIPT_DIR ~/.codex/skills/explainer${NC}"
+    fi
+    # If no agents detected, show all options
+    if [[ ${#DETECTED_AGENTS[@]} -eq 0 ]]; then
+        echo -e "     ${BOLD}Claude Code:${NC}  ${BLUE}cp -r $SCRIPT_DIR ~/.claude/skills/explainer${NC}"
+        echo -e "     ${BOLD}Amp:${NC}          ${BLUE}cp -r $SCRIPT_DIR ~/.config/agents/skills/explainer${NC}"
+        echo -e "     ${BOLD}OpenCode:${NC}     ${BLUE}cp -r $SCRIPT_DIR ~/.config/opencode/skills/explainer${NC}"
+        echo -e "     ${BOLD}Codex CLI:${NC}    ${BLUE}cp -r $SCRIPT_DIR ~/.codex/skills/explainer${NC}"
+    fi
+    echo ""
+    echo -e "     For rule-based agents (Cursor, Windsurf, Kilo, Roo, Cline),"
+    echo -e "     copy ${BLUE}SKILL.md${NC} into your agent's rules directory."
+    echo -e "     See the README for details."
+    echo ""
+    echo -e "  3. Use it: ${BLUE}/explainer <feature name>${NC}"
+fi
 echo ""
 echo -e "  ${BOLD}Modes:${NC}"
 echo -e "  • ${GREEN}Autoplay${NC}     — highlights + voice narration play automatically"


### PR DESCRIPTION
## Summary
- Replace Claude Code-only install paths in README with a table covering 9 agents
- Group agents into "skill-native" (Claude Code, Amp, OpenCode, Codex) and "rule-based" (Cursor, Windsurf, Kilo, Roo, Cline) with per-agent instructions
- Update `setup.sh` to detect available agents and print relevant copy commands instead of hardcoding `~/.claude/skills/explainer`

## Test plan
- [ ] Verify README markdown renders correctly on GitHub (tables, details block)
- [ ] Run `setup.sh` from a non-skills directory and confirm it shows all agent copy commands
- [ ] Run `setup.sh` from a `~/.claude/skills/explainer` path and confirm it skips the copy step

🤖 Generated with [Claude Code](https://claude.com/claude-code)