### PR TITLE
fix: only play segments on explicit play button click

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -149,6 +149,18 @@ export function activate(context: vscode.ExtensionContext): void {
 		const myGeneration = ++highlightLoopGeneration;
 
 		const highlights = segment.highlights;
+
+		// If not playing, just show the code location without starting TTS
+		if (wt.getState().status !== "playing") {
+			if (highlights && highlights.length > 0) {
+				await highlightSegmentRange(segment.file, segment.start, segment.end).catch(() => {});
+			} else {
+				highlightRange(segment.file, segment.start, segment.end).catch(() => {});
+			}
+			sb.updateState(wt.getState());
+			return;
+		}
+
 		if (!highlights || highlights.length === 0) {
 			// Fallback: single highlight, single TTS (legacy behavior)
 			highlightRange(segment.file, segment.start, segment.end).catch(() => {});
@@ -270,7 +282,7 @@ export function activate(context: vscode.ExtensionContext): void {
 				walkthrough.removeSegments(msg.ids);
 				break;
 			case "goto":
-				walkthrough.goto(msg.segmentId);
+				walkthrough.navigateTo(msg.segmentId);
 				break;
 			case "resume":
 				walkthrough.play();

--- a/vscode-extension/src/walkthrough.ts
+++ b/vscode-extension/src/walkthrough.ts
@@ -40,6 +40,10 @@ export class Walkthrough extends EventEmitter {
 		this.state = { title, segments, currentIndex: 0, currentHighlightIndex: 0, status: "paused" };
 		this.emit("plan", this.getState());
 		this.emit("status", this.state.status);
+		// Show the first segment (code location) without starting playback
+		if (segments.length > 0) {
+			this.emit("segment", segments[0]);
+		}
 	}
 
 	stop(): void {
@@ -104,6 +108,17 @@ export class Walkthrough extends EventEmitter {
 		this.state.currentHighlightIndex = 0;
 		this.state.status = "playing";
 		this.emit("status", this.state.status);
+		this.emit("segment", this.state.segments[idx]);
+		return true;
+	}
+
+	/** Navigate to a segment without changing playback status (no auto-play). */
+	navigateTo(segmentId: number): boolean {
+		const idx = this.state.segments.findIndex((s) => s.id === segmentId);
+		if (idx === -1) return false;
+		this.state.currentIndex = idx;
+		this.state.currentHighlightIndex = 0;
+		this.emit("plan", this.getState());
 		this.emit("segment", this.state.segments[idx]);
 		return true;
 	}


### PR DESCRIPTION
## Summary
- Gate segment highlights and TTS playback on "playing" status so nothing auto-plays when a plan loads or the agent navigates
- Add `navigateTo()` method for agent-initiated navigation that doesn't trigger playback
- On plan load, show the first segment's code location without starting audio

## Test plan
- [ ] Load a new plan → verify segments don't auto-play, code location is shown
- [ ] Click play → verify both highlights and audio start together
- [ ] Pause/resume → verify playback resumes correctly on play click
- [ ] Next/prev buttons → verify they still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)