### PR TITLE
feat: play button pulse animation + agent messaging fix

### DIFF
--- a/docs/step5-autoplay.md
+++ b/docs/step5-autoplay.md
@@ -40,7 +40,7 @@ EOF
 ~/.claude/skills/explainer/scripts/explainer.sh plan /tmp/walkthrough-plan.json
 ```
 
-Playback starts immediately.
+The sidebar loads the plan and shows the first segment's code location. Playback does NOT start automatically — the user must press the Play button on the sidebar to begin. Tell the user: **"Press ▶ Play on the sidebar to start the walkthrough."**
 
 3. **Handle user actions (optional):**
 

--- a/vscode-extension/media/sidebar.css
+++ b/vscode-extension/media/sidebar.css
@@ -102,6 +102,25 @@ body {
 	background: var(--vscode-button-secondaryHoverBackground);
 }
 
+/* ── Play button pulse animation ── */
+
+@keyframes play-pulse {
+	0%, 100% {
+		opacity: 1;
+		transform: scale(1);
+	}
+	50% {
+		opacity: 0.7;
+		transform: scale(1.1);
+	}
+}
+
+#btn-play-pause.pulse {
+	background: var(--vscode-button-background);
+	color: var(--vscode-button-foreground);
+	animation: play-pulse 1.5s ease-in-out infinite;
+}
+
 /* ── Audio controls ── */
 
 .audio-controls {

--- a/vscode-extension/media/sidebar.js
+++ b/vscode-extension/media/sidebar.js
@@ -232,6 +232,13 @@ function render() {
 	playBtn.textContent = state.status === "playing" ? "\u23F8" : "\u25B6";
 	playBtn.title = state.status === "playing" ? "Pause" : "Play";
 
+	// Pulse animation when paused (ready to play)
+	if (state.status === "paused") {
+		playBtn.classList.add("pulse");
+	} else {
+		playBtn.classList.remove("pulse");
+	}
+
 	// Explanation
 	if (seg) {
 		document.getElementById("explanation-text").innerHTML = simpleMarkdown(seg.explanation);


### PR DESCRIPTION
## Summary
- Add pulse animation (scale + opacity) on the play button when walkthrough is paused and ready to play, making it obvious where to click
- Update autoplay docs to instruct the agent to say "Press ▶ Play on the sidebar" instead of implying playback starts automatically

Follows up on #20 which gated playback behind the play button.

## Test plan
- [ ] Load a walkthrough → verify play button pulses when paused
- [ ] Click play → pulse stops, playback starts
- [ ] Pause → pulse resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)