### PR TITLE
Remove Go Deeper/Zoom Out buttons, add agent hint

### DIFF
--- a/vscode-extension/media/sidebar.css
+++ b/vscode-extension/media/sidebar.css
@@ -275,29 +275,24 @@ body {
 	font-size: 0.9em;
 }
 
-/* ── Action buttons ── */
+/* ── Agent hint ── */
 
-.action-buttons {
+.agent-hint {
 	display: flex;
+	align-items: center;
 	gap: 8px;
 	margin-bottom: 16px;
-}
-
-.action-buttons button {
-	flex: 1;
-	background: var(--vscode-button-secondaryBackground);
-	color: var(--vscode-button-secondaryForeground);
-	border: 1px solid transparent;
+	padding: 10px 12px;
+	background: var(--vscode-textBlockQuote-background);
+	border-left: 3px solid var(--vscode-textLink-foreground);
 	border-radius: 4px;
-	padding: 6px 10px;
 	font-size: 0.85em;
-	cursor: pointer;
-	transition: background 0.15s ease, border-color 0.15s ease;
+	color: var(--vscode-descriptionForeground);
 }
 
-.action-buttons button:hover {
-	background: var(--vscode-button-secondaryHoverBackground);
-	border-color: var(--vscode-panel-border);
+.agent-hint-icon {
+	font-size: 1.1em;
+	flex-shrink: 0;
 }
 
 /* ── Outline ── */

--- a/vscode-extension/media/sidebar.js
+++ b/vscode-extension/media/sidebar.js
@@ -352,16 +352,8 @@ document.getElementById("btn-prev").addEventListener("click", () => {
 	vscode.postMessage({ type: "prev" });
 });
 
-document.getElementById("btn-deeper").addEventListener("click", () => {
-	vscode.postMessage({ type: "go_deeper" });
-});
-
 document.getElementById("btn-restart").addEventListener("click", () => {
 	vscode.postMessage({ type: "restart" });
-});
-
-document.getElementById("btn-zoom-out").addEventListener("click", () => {
-	vscode.postMessage({ type: "zoom_out" });
 });
 
 document.getElementById("volume-slider").addEventListener("input", (e) => {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -329,30 +329,6 @@ export function activate(context: vscode.ExtensionContext): void {
 				sidebar.sendAudioStop();
 				walkthrough.goto(msg.segmentId);
 				break;
-			case "go_deeper": {
-				const segment = walkthrough.getCurrentSegment();
-				if (segment) {
-					walkthrough.pause();
-					server.queueAction({
-						type: "user_action",
-						action: "go_deeper",
-						segmentId: segment.id,
-					});
-				}
-				break;
-			}
-			case "zoom_out": {
-				const segment = walkthrough.getCurrentSegment();
-				if (segment) {
-					walkthrough.pause();
-					server.queueAction({
-						type: "user_action",
-						action: "zoom_out",
-						segmentId: segment.id,
-					});
-				}
-				break;
-			}
 			case "speed_change":
 				ttsSpeed = msg.speed;
 				break;

--- a/vscode-extension/src/sidebar.ts
+++ b/vscode-extension/src/sidebar.ts
@@ -183,9 +183,9 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 			<div id="explanation-text" class="explanation-text"></div>
 		</div>
 
-		<div class="action-buttons">
-			<button id="btn-deeper">Go Deeper</button>
-			<button id="btn-zoom-out">Zoom Out</button>
+		<div class="agent-hint">
+			<span class="agent-hint-icon">&#x1F4AC;</span>
+			Have questions? Ask your coding agent!
 		</div>
 
 		<div class="outline">

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -77,7 +77,7 @@ export interface StateMessage {
 
 export interface UserActionMessage {
 	type: "user_action";
-	action: "go_deeper" | "zoom_out" | "ask_question";
+	action: "ask_question";
 	segmentId: number;
 	question?: string;
 }
@@ -138,14 +138,6 @@ export interface WebviewGotoSegmentMessage {
 	segmentId: number;
 }
 
-export interface WebviewGoDeeperMessage {
-	type: "go_deeper";
-}
-
-export interface WebviewZoomOutMessage {
-	type: "zoom_out";
-}
-
 export interface WebviewSpeedChangeMessage {
 	type: "speed_change";
 	speed: number;
@@ -178,8 +170,6 @@ export type FromWebviewMessage =
 	| WebviewNextMessage
 	| WebviewPrevMessage
 	| WebviewGotoSegmentMessage
-	| WebviewGoDeeperMessage
-	| WebviewZoomOutMessage
 	| WebviewSpeedChangeMessage
 	| WebviewVolumeChangeMessage
 	| WebviewVoiceChangeMessage


### PR DESCRIPTION
## Summary
- Removed non-functional "Go Deeper" and "Zoom Out" buttons from the sidebar
- Replaced with a styled hint message: "Have questions? Ask your coding agent!"
- Cleaned up dead code (handlers, types, event listeners) related to the removed buttons

## Test plan
- [ ] Verify sidebar renders the agent hint message correctly
- [ ] Confirm no console errors from missing button elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)