### PR TITLE
docs: align field names with sidebar API schema

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -37,3 +37,5 @@ Complete these steps in order:
 | Sidebar check not parallelized | Dispatch Bash health check + AskUserQuestion in one response, not sequentially |
 | Text output when sidebar active | If health check returned ok, send plan JSON only — no terminal text |
 | Sub-highlights too broad | 5-15 lines each, target 30-60% coverage of segment, not a partition of the full range |
+| Wrong field names in sidebar JSON | Use `start`/`end`/`title`/`ttsText`/`highlights` — NOT `startLine`/`endLine`/`label`/`subHighlights`. See `docs/plan.md` step 3a for exact schema |
+| Skipping `set_plan` before `goto` | Sidebar needs the full plan loaded first. Always send `set_plan` via `explainer.sh plan` before any `goto` messages |

--- a/docs/interactive.md
+++ b/docs/interactive.md
@@ -2,6 +2,11 @@
 
 **If Autoplay was chosen, use `docs/autoplay.md` instead.**
 
+## 5-pre. Send plan to sidebar (if not already sent in step 3)
+
+If the sidebar is active and you haven't already sent `set_plan` in step 3, send it now.
+The sidebar needs the full plan before `goto` messages will work. See `docs/plan.md` step 3a for the `set_plan` JSON schema and send command.
+
 For each segment:
 
 ## 5a. Highlight in VS Code
@@ -15,7 +20,7 @@ Sidebar active (from step 0):
 
 Fallback (no sidebar):
 ```bash
-echo '{"file":"{absolute_filepath}","start":{startLine},"end":{endLine}}' > ~/.claude-highlight.json
+echo '{"file":"{absolute_filepath}","start":{start},"end":{end}}' > ~/.claude-highlight.json
 ```
 
 Always use absolute file paths.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,14 +1,53 @@
 # Step 3: Build + Present Plan
 
-Parse the sub-agent's response into ordered segments:
-
-```
-{number}. {file}:{startLine}-{endLine} -- {brief description} [{complexity}]
-```
+Parse the sub-agent's response into ordered segments.
 
 **Verify:** segments ordered by call flow, within size limits for chosen depth, absolute paths used. Split if needed.
 
-**Present to user:**
+## 3a. Send plan to sidebar (if active)
+
+Build a `set_plan` JSON message matching the sidebar API schema exactly:
+
+```json
+{
+  "type": "set_plan",
+  "title": "Feature Name Walkthrough",
+  "segments": [
+    {
+      "id": 1,
+      "file": "/absolute/path/to/file.ts",
+      "start": 10,
+      "end": 45,
+      "title": "HTTP endpoint, request validation",
+      "explanation": "",
+      "ttsText": "",
+      "highlights": [
+        { "start": 10, "end": 20, "ttsText": "Plain text narration for this sub-range." },
+        { "start": 25, "end": 40, "ttsText": "Plain text narration for this sub-range." }
+      ]
+    }
+  ]
+}
+```
+
+**Field reference** (from `vscode-extension/src/types.ts`):
+- `id`: sequential integer
+- `file`: absolute path
+- `start` / `end`: 1-based line numbers (NOT `startLine` / `endLine`)
+- `title`: short segment label (NOT `label` or `description`)
+- `explanation`: markdown explanation (can be empty at plan time, filled during walkthrough)
+- `ttsText`: plain-text narration (can be empty at plan time, filled during walkthrough)
+- `highlights`: optional sub-ranges, each with `start`, `end`, `ttsText`
+
+Send via:
+```bash
+cat > /tmp/walkthrough-plan.json << 'EOF'
+{ "type": "set_plan", "title": "...", "segments": [...] }
+EOF
+~/.claude/skills/explainer/scripts/explainer.sh plan /tmp/walkthrough-plan.json
+```
+
+## 3b. Present to user
 
 ```
 I'll walk through {feature} in {N} segments:

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -22,9 +22,14 @@ Return a structured result:
 - **Core files**: list of files with brief description of each
 - **Call chain**: what calls what (A -> B -> C)
 - **Walkthrough plan**: ordered list of segments, each as:
-  {file_absolute_path}:{startLine}-{endLine} -- {brief description} [{complexity}]
+  {file_absolute_path}:{start}-{end} -- {title} [{complexity}]
     Sub-highlights (2-5 per segment):
-      - {startLine}-{endLine} -- {brief description of this sub-range}
+      - {start}-{end} -- {ttsText: 1-2 sentence plain-text narration}
+
+  IMPORTANT — field names must match the sidebar API exactly:
+  - `start` / `end` (not startLine / endLine)
+  - `title` (not label or description)
+  - Sub-highlights use `start` / `end` / `ttsText`
 
   {complexity} is one of:
   - `[core]` — central logic. Explain thoroughly.


### PR DESCRIPTION
## Summary
- Fix field naming across docs to match `vscode-extension/src/types.ts` (`start`/`end` not `startLine`/`endLine`, `title` not `label`, `highlights` not `subHighlights`)
- Add exact `set_plan` JSON schema and send instructions to `docs/plan.md`
- Add pitfall entries to `SKILL.md` for wrong field names and missing `set_plan` step
- Add pre-step in `docs/interactive.md` to ensure plan is sent before `goto` messages

## Test plan
- [ ] Verify field names match `vscode-extension/src/types.ts` types
- [ ] Confirm `set_plan` JSON example is valid against sidebar API

🤖 Generated with [Claude Code](https://claude.com/claude-code)