### PR TITLE
fix: subsegment nav bugs and memory leak

### DIFF
--- a/vscode-extension/media/sidebar.css
+++ b/vscode-extension/media/sidebar.css
@@ -147,9 +147,15 @@ body {
 	pointer-events: auto;
 }
 
-.controls .highlight-btn.visible:hover {
+.controls .highlight-btn.visible:hover:not(:disabled) {
 	opacity: 1;
 	background: var(--vscode-button-secondaryHoverBackground);
+}
+
+.controls .highlight-btn.visible:disabled {
+	opacity: 0.25;
+	cursor: default;
+	pointer-events: none;
 }
 
 /* ── Play button (circular) ── */

--- a/vscode-extension/media/sidebar.js
+++ b/vscode-extension/media/sidebar.js
@@ -103,6 +103,11 @@ function playAudioChunk(base64Data, sampleRate) {
 
 function stopAudio() {
 	for (const source of activeSources) {
+		// Clear onended BEFORE stopping to prevent stale playback_complete messages.
+		// Without this, wrapped onended callbacks (from waitForActiveSourcesToFinish)
+		// fire and send playback_complete which can resolve the NEXT chunk's promise,
+		// causing the highlight loop to skip subsegments and leak orphaned TTS streams.
+		source.onended = null;
 		try { source.stop(); } catch {}
 	}
 	activeSources = [];
@@ -296,6 +301,9 @@ function renderHighlightProgress() {
 			`${idx + 1}/${state.segments.length} · ${currentHighlightIndex + 1}/${totalHighlights}`;
 		prevHighlightBtn.classList.add("visible");
 		nextHighlightBtn.classList.add("visible");
+		// Disable at boundaries — subsegment buttons don't cross segment boundaries
+		prevHighlightBtn.disabled = currentHighlightIndex <= 0;
+		nextHighlightBtn.disabled = currentHighlightIndex >= totalHighlights - 1;
 	} else {
 		counter.textContent = `${idx + 1}/${state.segments.length}`;
 		prevHighlightBtn.classList.remove("visible");

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -150,6 +150,7 @@ export function activate(context: vscode.ExtensionContext): void {
 	function preWarmAndResume(startHighlight: number): void {
 		const seg = walkthrough.getCurrentSegment();
 		if (!seg) return;
+		highlightLoopGeneration++;
 		if (currentChunkAbort) { currentChunkAbort(); currentChunkAbort = undefined; }
 		sidebar.sendAudioStop();
 		sidebar.sendServerLoading(true);
@@ -343,32 +344,23 @@ export function activate(context: vscode.ExtensionContext): void {
 				if (seg?.highlights && seg.highlights.length > 0) {
 					const curIdx = walkthrough.getHighlightIndex();
 					if (curIdx >= seg.highlights.length - 1) {
-						// At last sub-segment — advance to next segment
-						if (currentChunkAbort) { currentChunkAbort(); currentChunkAbort = undefined; }
-						if (abortTTS) { abortTTS(); abortTTS = undefined; }
-						sidebar.sendAudioStop();
-						walkthrough.next();
-					} else {
-						const nextIdx = curIdx + 1;
-						if (currentChunkAbort) { currentChunkAbort(); currentChunkAbort = undefined; }
-						if (abortTTS) { abortTTS(); abortTTS = undefined; }
-						sidebar.sendAudioStop();
-						walkthrough.setHighlightIndex(nextIdx);
-						if (walkthrough.getState().status === "playing") {
-							playSegmentHighlights(seg, walkthrough, sidebar, nextIdx).catch((err) => {
-								console.error("[code-explainer] Highlight loop error:", err);
-							});
-						} else {
-							sidebar.sendHighlightAdvance(nextIdx, seg.highlights.length);
-							highlightSubRange(seg.file, seg.highlights[nextIdx].start, seg.highlights[nextIdx].end).catch(() => {});
-						}
+						// At last sub-segment — stay put (use segment-level next to advance)
+						break;
 					}
-				} else {
-					// No highlights — skip to next segment
+					const nextIdx = curIdx + 1;
+					highlightLoopGeneration++;
 					if (currentChunkAbort) { currentChunkAbort(); currentChunkAbort = undefined; }
 					if (abortTTS) { abortTTS(); abortTTS = undefined; }
 					sidebar.sendAudioStop();
-					walkthrough.next();
+					walkthrough.setHighlightIndex(nextIdx);
+					if (walkthrough.getState().status === "playing") {
+						playSegmentHighlights(seg, walkthrough, sidebar, nextIdx).catch((err) => {
+							console.error("[code-explainer] Highlight loop error:", err);
+						});
+					} else {
+						sidebar.sendHighlightAdvance(nextIdx, seg.highlights.length);
+						highlightSubRange(seg.file, seg.highlights[nextIdx].start, seg.highlights[nextIdx].end).catch(() => {});
+					}
 				}
 				break;
 			}
@@ -377,32 +369,23 @@ export function activate(context: vscode.ExtensionContext): void {
 				if (seg?.highlights && seg.highlights.length > 0) {
 					const curIdx = walkthrough.getHighlightIndex();
 					if (curIdx <= 0) {
-						// At first sub-segment — go to previous segment
-						if (currentChunkAbort) { currentChunkAbort(); currentChunkAbort = undefined; }
-						if (abortTTS) { abortTTS(); abortTTS = undefined; }
-						sidebar.sendAudioStop();
-						walkthrough.prev();
-					} else {
-						const prevIdx = curIdx - 1;
-						if (currentChunkAbort) { currentChunkAbort(); currentChunkAbort = undefined; }
-						if (abortTTS) { abortTTS(); abortTTS = undefined; }
-						sidebar.sendAudioStop();
-						walkthrough.setHighlightIndex(prevIdx);
-						if (walkthrough.getState().status === "playing") {
-							playSegmentHighlights(seg, walkthrough, sidebar, prevIdx).catch((err) => {
-								console.error("[code-explainer] Highlight loop error:", err);
-							});
-						} else {
-							sidebar.sendHighlightAdvance(prevIdx, seg.highlights.length);
-							highlightSubRange(seg.file, seg.highlights[prevIdx].start, seg.highlights[prevIdx].end).catch(() => {});
-						}
+						// At first sub-segment — stay put (use segment-level prev to go back)
+						break;
 					}
-				} else {
-					// No highlights — skip to prev segment
+					const prevIdx = curIdx - 1;
+					highlightLoopGeneration++;
 					if (currentChunkAbort) { currentChunkAbort(); currentChunkAbort = undefined; }
 					if (abortTTS) { abortTTS(); abortTTS = undefined; }
 					sidebar.sendAudioStop();
-					walkthrough.prev();
+					walkthrough.setHighlightIndex(prevIdx);
+					if (walkthrough.getState().status === "playing") {
+						playSegmentHighlights(seg, walkthrough, sidebar, prevIdx).catch((err) => {
+							console.error("[code-explainer] Highlight loop error:", err);
+						});
+					} else {
+						sidebar.sendHighlightAdvance(prevIdx, seg.highlights.length);
+						highlightSubRange(seg.file, seg.highlights[prevIdx].start, seg.highlights[prevIdx].end).catch(() => {});
+					}
 				}
 				break;
 			}


### PR DESCRIPTION
## Summary
- **Subsegment buttons no longer cross segment boundaries** — prev at first subsegment and next at last subsegment now stay put instead of jumping to adjacent segments
- **Fixed stale `playback_complete` memory leak** — cleared `source.onended` before `source.stop()` in `stopAudio()` to prevent wrapped callbacks from resolving the wrong promise, which caused subsegment skips and orphaned TTS streams (root cause of the 50GB memory crash)
- **Added `highlightLoopGeneration` guards** in nav handlers and `preWarmAndResume` to ensure old playback loops always exit
- **Disabled buttons at boundaries** with visual styling (25% opacity)

## Test plan
- [ ] Navigate to first segment with multiple subsegments, verify prev-subsegment button is disabled and does nothing
- [ ] Navigate to last subsegment of any segment, verify next-subsegment button is disabled and does nothing
- [ ] Click next-subsegment mid-segment, verify it advances one subsegment without skipping
- [ ] Monitor VS Code memory usage during extended walkthrough with frequent subsegment navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)