### PR TITLE
fix: prevent highlight freeze after pause/resume

### DIFF
--- a/vscode-extension/media/sidebar.js
+++ b/vscode-extension/media/sidebar.js
@@ -31,6 +31,8 @@ let currentHighlightIndex = 0;
 let totalHighlights = 0;
 /** True when audio_end arrived but chunks are still pending (AudioContext suspended) */
 let deferredPlaybackComplete = false;
+/** Guard: true while waitForActiveSourcesToFinish has a pending wrapper or sent playback_complete */
+let playbackCompleteWired = false;
 
 /** @type {{base64: string, sampleRate: number}[]} */
 let pendingChunks = [];
@@ -117,6 +119,7 @@ function stopAudio() {
 	nextPlayTime = 0;
 	audioPlaying = false;
 	deferredPlaybackComplete = false;
+	playbackCompleteWired = false;
 }
 
 /** Suspend AudioContext to freeze audio in place (pause mid-highlight). */
@@ -131,7 +134,9 @@ function suspendAudio() {
 /** Resume AudioContext and wait for remaining buffered audio to finish. */
 function resumeAudio() {
 	intentionallySuspended = false;
-	if (audioCtx && audioCtx.state === "suspended" && activeSources.length > 0) {
+	if (audioCtx && audioCtx.state === "suspended") {
+		// Always resume the AudioContext so subsequent playAudioChunk() calls
+		// don't silently push to pendingChunks instead of playing.
 		audioCtx.resume().then(() => {
 			waitForActiveSourcesToFinish();
 		});
@@ -144,10 +149,15 @@ function resumeAudio() {
 /**
  * Wait for all active audio sources to finish, then send playback_complete.
  * If no sources are active (already drained), sends immediately.
+ * Idempotent: safe to call multiple times (onAudioEnd + resumeAudio) —
+ * only the first call wires the wrapper; subsequent calls are no-ops.
  */
 function waitForActiveSourcesToFinish() {
+	if (playbackCompleteWired) return;
+	playbackCompleteWired = true;
 	if (activeSources.length === 0) {
 		audioPlaying = false;
+		playbackCompleteWired = false;
 		vscode.postMessage({ type: "playback_complete" });
 		return;
 	}
@@ -156,6 +166,7 @@ function waitForActiveSourcesToFinish() {
 	lastSource.onended = (e) => {
 		if (originalOnEnded) originalOnEnded.call(lastSource, e);
 		audioPlaying = false;
+		playbackCompleteWired = false;
 		vscode.postMessage({ type: "playback_complete" });
 	};
 }

--- a/vscode-extension/media/sidebar.js
+++ b/vscode-extension/media/sidebar.js
@@ -153,7 +153,7 @@ function resumeAudio() {
  * only the first call wires the wrapper; subsequent calls are no-ops.
  */
 function waitForActiveSourcesToFinish() {
-	if (playbackCompleteWired) return;
+	if (playbackCompleteWired || intentionallySuspended) return;
 	playbackCompleteWired = true;
 	if (activeSources.length === 0) {
 		audioPlaying = false;

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -200,35 +200,15 @@ export function activate(context: vscode.ExtensionContext): void {
 		hasSuspendedAudio = false;
 	}
 
-	/** Resume from suspended audio — plays remaining buffered audio, then continues to next highlight. */
+	/**
+	 * Resume from suspended audio — just unpause the AudioContext.
+	 * The original playSegmentHighlights loop is still alive (paused at `await playbackDone`)
+	 * with its chunkPlayedCallback intact, so highlights will continue advancing
+	 * as the buffered audio plays out.
+	 */
 	function resumeFromSuspended(): void {
 		hasSuspendedAudio = false;
-		const seg = walkthrough.getCurrentSegment();
-		if (!seg) return;
-		highlightLoopGeneration++;
-		const myGeneration = highlightLoopGeneration;
-		const highlightIdx = walkthrough.getHighlightIndex();
-
 		sidebar.sendAudioResume();
-
-		// Wait for the remaining buffered audio to finish.
-		// Order matters: sendAudioResume posts to webview (always async via iframe postMessage),
-		// so the playback_complete response will arrive after waitForPlaybackComplete installs its resolver.
-		sidebar.waitForPlaybackComplete().then(() => {
-			if (myGeneration !== highlightLoopGeneration) return;
-			if (walkthrough.getState().status !== "playing") return;
-
-			// Continue from the next highlight
-			const nextIdx = highlightIdx + 1;
-			if (nextIdx < seg.highlights.length) {
-				playSegmentHighlights(seg, walkthrough, sidebar, nextIdx).catch((err) => {
-					console.error("[code-explainer] Highlight loop error:", err);
-				});
-			} else {
-				// All highlights done — auto-advance to next segment
-				walkthrough.next();
-			}
-		});
 	}
 
 	/** Pre-warm the TTS server then resume playback from a specific highlight index. */
@@ -406,12 +386,14 @@ export function activate(context: vscode.ExtensionContext): void {
 				currentChunkAbort();
 				currentChunkAbort = undefined;
 			}
-			highlightLoopGeneration++;
-			// On pause, suspend audio (freeze in place) for exact-position resume.
-			// On "stopped" (natural end), let webview audio drain naturally.
 			if (state.status === "paused") {
+				// Suspend audio but keep the highlight loop alive — don't
+				// increment highlightLoopGeneration so the chunkPlayedCallback
+				// remains valid and can advance highlights when audio resumes.
 				sidebar.sendAudioSuspend();
 				hasSuspendedAudio = true;
+			} else {
+				highlightLoopGeneration++;
 			}
 		}
 

--- a/vscode-extension/src/sidebar.ts
+++ b/vscode-extension/src/sidebar.ts
@@ -93,9 +93,9 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 	/** Suspend audio in webview (freeze in place for mid-highlight pause). */
 	sendAudioSuspend(): void {
 		this.postMessage({ type: "audio_suspend" });
-		// Resolve any pending playback wait so the old highlight loop can exit
-		this.playbackCompleteResolve?.();
-		this.playbackCompleteResolve = undefined;
+		// Do NOT resolve playbackCompleteResolve here. Keeping the old
+		// playSegmentHighlights loop alive at `await playbackDone` preserves
+		// the chunkPlayedCallback so highlights continue advancing on resume.
 	}
 
 	/** Resume suspended audio in webview. */


### PR DESCRIPTION
## Summary
- Fix editor highlights freezing after pause/resume via sidebar
- `waitForActiveSourcesToFinish()` was being called twice (once from `onAudioEnd`, once from `resumeAudio`), double-wrapping the last source's `onended` and sending two `playback_complete` messages — the second prematurely resolved `playSegmentHighlights`' promise and cleared `chunkPlayedCallback`
- Added `playbackCompleteWired` guard to make `waitForActiveSourcesToFinish` idempotent
- Also always resume AudioContext regardless of `activeSources` count to prevent edge case where context stays suspended

## Test plan
- [ ] Start a walkthrough with TTS enabled
- [ ] Let it play for a few seconds (so TTS finishes streaming)
- [ ] Pause via sidebar play/pause button
- [ ] Resume via sidebar play/pause button
- [ ] Verify editor highlights continue advancing with audio
- [ ] Verify clicking next/prev segment still works correctly
- [ ] Verify spacebar hold-to-pause still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)